### PR TITLE
Generate docs for built‑in extensions

### DIFF
--- a/docs/extension-architecture/README.md
+++ b/docs/extension-architecture/README.md
@@ -1,0 +1,11 @@
+# Extension Architecture Docs
+
+This folder contains auto-generated documentation for VS Code's built-in extensions.
+Each Markdown file summarizes key architectural details extracted from the extension's
+`package.json` (and `package.nls.json` when present).
+
+To regenerate these files, run:
+
+```bash
+node scripts/generateExtensionDocs.js
+```

--- a/docs/extension-architecture/bat.md
+++ b/docs/extension-architecture/bat.md
@@ -1,0 +1,9 @@
+# Windows Bat Language Basics
+
+**Extension ID:** bat
+
+Provides snippets, syntax highlighting, bracket matching and folding in Windows batch files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/clojure.md
+++ b/docs/extension-architecture/clojure.md
@@ -1,0 +1,9 @@
+# Clojure Language Basics
+
+**Extension ID:** clojure
+
+Provides syntax highlighting and bracket matching in Clojure files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/coffeescript.md
+++ b/docs/extension-architecture/coffeescript.md
@@ -1,0 +1,9 @@
+# CoffeeScript Language Basics
+
+**Extension ID:** coffeescript
+
+Provides snippets, syntax highlighting, bracket matching and folding in CoffeeScript files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, breakpoints, snippets, configurationDefaults

--- a/docs/extension-architecture/configuration-editing.md
+++ b/docs/extension-architecture/configuration-editing.md
@@ -1,0 +1,9 @@
+# Configuration Editing
+
+**Extension ID:** configuration-editing
+
+Provides capabilities (advanced IntelliSense, auto-fixing) in configuration files like settings, launch, and extension recommendation files.
+
+* **Entry Point:** `./out/configurationEditingMain`
+* **Activation Events:** onProfile, onProfile:github, onLanguage:json, onLanguage:jsonc
+* **Contribution Points:** languages, jsonValidation

--- a/docs/extension-architecture/cpp.md
+++ b/docs/extension-architecture/cpp.md
@@ -1,0 +1,9 @@
+# C/C++ Language Basics
+
+**Extension ID:** cpp
+
+Provides snippets, syntax highlighting, bracket matching and folding in C/C++ files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, problemPatterns, problemMatchers, snippets

--- a/docs/extension-architecture/csharp.md
+++ b/docs/extension-architecture/csharp.md
@@ -1,0 +1,9 @@
+# C# Language Basics
+
+**Extension ID:** csharp
+
+Provides snippets, syntax highlighting, bracket matching and folding in C# files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** configurationDefaults, languages, grammars, snippets

--- a/docs/extension-architecture/css-language-features.md
+++ b/docs/extension-architecture/css-language-features.md
@@ -1,0 +1,9 @@
+# CSS Language Features
+
+**Extension ID:** css-language-features
+
+Provides rich language support for CSS, LESS and SCSS files.
+
+* **Entry Point:** `./client/out/node/cssClientMain`
+* **Activation Events:** onLanguage:css, onLanguage:less, onLanguage:scss, onCommand:_css.applyCodeAction
+* **Contribution Points:** configuration, configurationDefaults, jsonValidation

--- a/docs/extension-architecture/css.md
+++ b/docs/extension-architecture/css.md
@@ -1,0 +1,9 @@
+# CSS Language Basics
+
+**Extension ID:** css
+
+Provides syntax highlighting and bracket matching for CSS, LESS and SCSS files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/dart.md
+++ b/docs/extension-architecture/dart.md
@@ -1,0 +1,9 @@
+# Dart Language Basics
+
+**Extension ID:** dart
+
+Provides syntax highlighting & bracket matching in Dart files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/debug-auto-launch.md
+++ b/docs/extension-architecture/debug-auto-launch.md
@@ -1,0 +1,9 @@
+# Node Debug Auto-attach
+
+**Extension ID:** debug-auto-launch
+
+Helper for auto-attach feature when node-debug extensions are not active.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onStartupFinished
+* **Contribution Points:** commands

--- a/docs/extension-architecture/debug-server-ready.md
+++ b/docs/extension-architecture/debug-server-ready.md
@@ -1,0 +1,9 @@
+# Server Ready Action
+
+**Extension ID:** debug-server-ready
+
+Open URI in browser if server under debugging is ready.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onDebugResolve
+* **Contribution Points:** debuggers

--- a/docs/extension-architecture/diff.md
+++ b/docs/extension-architecture/diff.md
@@ -1,0 +1,9 @@
+# Diff Language Basics
+
+**Extension ID:** diff
+
+Provides syntax highlighting & bracket matching in Diff files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/docker.md
+++ b/docs/extension-architecture/docker.md
@@ -1,0 +1,9 @@
+# Docker Language Basics
+
+**Extension ID:** docker
+
+Provides syntax highlighting and bracket matching in Docker files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/emmet.md
+++ b/docs/extension-architecture/emmet.md
@@ -1,0 +1,9 @@
+# Emmet
+
+**Extension ID:** emmet
+
+Emmet support for VS Code
+
+* **Entry Point:** `./out/node/emmetNodeMain`
+* **Activation Events:** onCommand:emmet.expandAbbreviation, onLanguage
+* **Contribution Points:** configuration, commands, menus

--- a/docs/extension-architecture/extension-editing.md
+++ b/docs/extension-architecture/extension-editing.md
@@ -1,0 +1,9 @@
+# Extension Authoring
+
+**Extension ID:** extension-editing
+
+Provides linting capabilities for authoring extensions.
+
+* **Entry Point:** `./out/extensionEditingMain`
+* **Activation Events:** onLanguage:json, onLanguage:markdown
+* **Contribution Points:** jsonValidation, languages

--- a/docs/extension-architecture/fsharp.md
+++ b/docs/extension-architecture/fsharp.md
@@ -1,0 +1,9 @@
+# F# Language Basics
+
+**Extension ID:** fsharp
+
+Provides snippets, syntax highlighting, bracket matching and folding in F# files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets, configurationDefaults

--- a/docs/extension-architecture/git-base.md
+++ b/docs/extension-architecture/git-base.md
@@ -1,0 +1,9 @@
+# Git Base
+
+**Extension ID:** git-base
+
+Git static contributions and pickers.
+
+* **Entry Point:** `./out/extension.js`
+* **Activation Events:** *
+* **Contribution Points:** commands, menus, languages, grammars

--- a/docs/extension-architecture/git.md
+++ b/docs/extension-architecture/git.md
@@ -1,0 +1,9 @@
+# Git
+
+**Extension ID:** git
+
+Git SCM Integration
+
+* **Entry Point:** `./out/main`
+* **Activation Events:** *, onEditSession:file, onFileSystem:git, onFileSystem:git-show
+* **Contribution Points:** commands, continueEditSession, keybindings, menus, submenus, configuration, colors, configurationDefaults, viewsWelcome

--- a/docs/extension-architecture/github-authentication.md
+++ b/docs/extension-architecture/github-authentication.md
@@ -1,0 +1,9 @@
+# GitHub Authentication
+
+**Extension ID:** github-authentication
+
+GitHub Authentication Provider
+
+* **Entry Point:** `./out/extension.js`
+* **Activation Events:** 
+* **Contribution Points:** authentication, configuration

--- a/docs/extension-architecture/github.md
+++ b/docs/extension-architecture/github.md
@@ -1,0 +1,9 @@
+# GitHub
+
+**Extension ID:** github
+
+GitHub features for VS Code
+
+* **Entry Point:** `./out/extension.js`
+* **Activation Events:** *
+* **Contribution Points:** commands, continueEditSession, menus, configuration, viewsWelcome, markdown.previewStyles

--- a/docs/extension-architecture/go.md
+++ b/docs/extension-architecture/go.md
@@ -1,0 +1,9 @@
+# Go Language Basics
+
+**Extension ID:** go
+
+Provides syntax highlighting and bracket matching in Go files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/groovy.md
+++ b/docs/extension-architecture/groovy.md
@@ -1,0 +1,9 @@
+# Groovy Language Basics
+
+**Extension ID:** groovy
+
+Provides snippets, syntax highlighting and bracket matching in Groovy files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/grunt.md
+++ b/docs/extension-architecture/grunt.md
@@ -1,0 +1,9 @@
+# Grunt support for VS Code
+
+**Extension ID:** grunt
+
+Extension to add Grunt capabilities to VS Code.
+
+* **Entry Point:** `./out/main`
+* **Activation Events:** onTaskType:grunt
+* **Contribution Points:** configuration, taskDefinitions

--- a/docs/extension-architecture/gulp.md
+++ b/docs/extension-architecture/gulp.md
@@ -1,0 +1,9 @@
+# Gulp support for VSCode
+
+**Extension ID:** gulp
+
+Extension to add Gulp capabilities to VSCode.
+
+* **Entry Point:** `./out/main`
+* **Activation Events:** onTaskType:gulp
+* **Contribution Points:** configuration, taskDefinitions

--- a/docs/extension-architecture/handlebars.md
+++ b/docs/extension-architecture/handlebars.md
@@ -1,0 +1,9 @@
+# Handlebars Language Basics
+
+**Extension ID:** handlebars
+
+Provides syntax highlighting and bracket matching in Handlebars files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, htmlLanguageParticipants

--- a/docs/extension-architecture/hlsl.md
+++ b/docs/extension-architecture/hlsl.md
@@ -1,0 +1,9 @@
+# HLSL Language Basics
+
+**Extension ID:** hlsl
+
+Provides syntax highlighting and bracket matching in HLSL files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/html-language-features.md
+++ b/docs/extension-architecture/html-language-features.md
@@ -1,0 +1,9 @@
+# HTML Language Features
+
+**Extension ID:** html-language-features
+
+Provides rich language support for HTML and Handlebar files
+
+* **Entry Point:** `./client/out/node/htmlClientMain`
+* **Activation Events:** onLanguage:html, onLanguage:handlebars
+* **Contribution Points:** configuration, configurationDefaults, jsonValidation

--- a/docs/extension-architecture/html.md
+++ b/docs/extension-architecture/html.md
@@ -1,0 +1,9 @@
+# HTML Language Basics
+
+**Extension ID:** html
+
+Provides syntax highlighting, bracket matching & snippets in HTML files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/ini.md
+++ b/docs/extension-architecture/ini.md
@@ -1,0 +1,9 @@
+# Ini Language Basics
+
+**Extension ID:** ini
+
+Provides syntax highlighting and bracket matching in Ini files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/ipynb.md
+++ b/docs/extension-architecture/ipynb.md
@@ -1,0 +1,9 @@
+# .ipynb Support
+
+**Extension ID:** ipynb
+
+Provides basic support for opening and reading Jupyter's .ipynb notebook files
+
+* **Entry Point:** `./out/ipynbMain.node.js`
+* **Activation Events:** onNotebook:jupyter-notebook, onNotebookSerializer:interactive, onNotebookSerializer:repl
+* **Contribution Points:** configuration, commands, notebooks, notebookRenderer, menus

--- a/docs/extension-architecture/jake.md
+++ b/docs/extension-architecture/jake.md
@@ -1,0 +1,9 @@
+# Jake support for VS Code
+
+**Extension ID:** jake
+
+Extension to add Jake capabilities to VS Code.
+
+* **Entry Point:** `./out/main`
+* **Activation Events:** onTaskType:jake
+* **Contribution Points:** configuration, taskDefinitions

--- a/docs/extension-architecture/java.md
+++ b/docs/extension-architecture/java.md
@@ -1,0 +1,9 @@
+# Java Language Basics
+
+**Extension ID:** java
+
+Provides snippets, syntax highlighting, bracket matching and folding in Java files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/javascript.md
+++ b/docs/extension-architecture/javascript.md
@@ -1,0 +1,9 @@
+# JavaScript Language Basics
+
+**Extension ID:** javascript
+
+Provides snippets, syntax highlighting, bracket matching and folding in JavaScript files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** configurationDefaults, languages, grammars, semanticTokenScopes, snippets

--- a/docs/extension-architecture/json-language-features.md
+++ b/docs/extension-architecture/json-language-features.md
@@ -1,0 +1,9 @@
+# JSON Language Features
+
+**Extension ID:** json-language-features
+
+Provides rich language support for JSON files.
+
+* **Entry Point:** `./client/out/node/jsonClientMain`
+* **Activation Events:** onLanguage:json, onLanguage:jsonc, onLanguage:snippets, onCommand:json.validate
+* **Contribution Points:** configuration, configurationDefaults, jsonValidation, commands

--- a/docs/extension-architecture/json.md
+++ b/docs/extension-architecture/json.md
@@ -1,0 +1,9 @@
+# JSON Language Basics
+
+**Extension ID:** json
+
+Provides syntax highlighting & bracket matching in JSON files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/julia.md
+++ b/docs/extension-architecture/julia.md
@@ -1,0 +1,9 @@
+# Julia Language Basics
+
+**Extension ID:** julia
+
+Provides syntax highlighting & bracket matching in Julia files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/latex.md
+++ b/docs/extension-architecture/latex.md
@@ -1,0 +1,9 @@
+# LaTeX Language Basics
+
+**Extension ID:** latex
+
+Provides syntax highlighting and bracket matching for TeX, LaTeX and BibTeX.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/less.md
+++ b/docs/extension-architecture/less.md
@@ -1,0 +1,9 @@
+# Less Language Basics
+
+**Extension ID:** less
+
+Provides syntax highlighting, bracket matching and folding in Less files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, problemMatchers

--- a/docs/extension-architecture/log.md
+++ b/docs/extension-architecture/log.md
@@ -1,0 +1,9 @@
+# Log
+
+**Extension ID:** log
+
+Provides syntax highlighting for files with .log extension.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/lua.md
+++ b/docs/extension-architecture/lua.md
@@ -1,0 +1,9 @@
+# Lua Language Basics
+
+**Extension ID:** lua
+
+Provides syntax highlighting and bracket matching in Lua files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/make.md
+++ b/docs/extension-architecture/make.md
@@ -1,0 +1,9 @@
+# Make Language Basics
+
+**Extension ID:** make
+
+Provides syntax highlighting and bracket matching in Make files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/markdown-basics.md
+++ b/docs/extension-architecture/markdown-basics.md
@@ -1,0 +1,9 @@
+# Markdown Language Basics
+
+**Extension ID:** markdown
+
+Provides snippets and syntax highlighting for Markdown.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets, configurationDefaults

--- a/docs/extension-architecture/markdown-language-features.md
+++ b/docs/extension-architecture/markdown-language-features.md
@@ -1,0 +1,9 @@
+# Markdown Language Features
+
+**Extension ID:** markdown-language-features
+
+Provides rich language support for Markdown.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onLanguage:markdown, onLanguage:prompt, onLanguage:instructions, onLanguage:chatmode, onCommand:markdown.api.render, onCommand:markdown.api.reloadPlugins, onWebviewPanel:markdown.preview
+* **Contribution Points:** notebookRenderer, commands, menus, keybindings, configuration, configurationDefaults, jsonValidation, markdown.previewStyles, markdown.previewScripts, customEditors

--- a/docs/extension-architecture/markdown-math.md
+++ b/docs/extension-architecture/markdown-math.md
@@ -1,0 +1,9 @@
+# Markdown Math
+
+**Extension ID:** markdown-math
+
+Adds math support to Markdown in notebooks.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** 
+* **Contribution Points:** languages, grammars, notebookRenderer, markdown.markdownItPlugins, markdown.previewStyles, configuration

--- a/docs/extension-architecture/media-preview.md
+++ b/docs/extension-architecture/media-preview.md
@@ -1,0 +1,9 @@
+# Media Preview
+
+**Extension ID:** media-preview
+
+Provides VS Code's built-in previews for images, audio, and video
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** 
+* **Contribution Points:** configuration, customEditors, commands, menus

--- a/docs/extension-architecture/merge-conflict.md
+++ b/docs/extension-architecture/merge-conflict.md
@@ -1,0 +1,9 @@
+# Merge Conflict
+
+**Extension ID:** merge-conflict
+
+Highlighting and commands for inline merge conflicts.
+
+* **Entry Point:** `./out/mergeConflictMain`
+* **Activation Events:** onStartupFinished
+* **Contribution Points:** commands, menus, configuration

--- a/docs/extension-architecture/microsoft-authentication.md
+++ b/docs/extension-architecture/microsoft-authentication.md
@@ -1,0 +1,9 @@
+# Microsoft Account
+
+**Extension ID:** microsoft-authentication
+
+Microsoft authentication provider
+
+* **Entry Point:** `./out/extension.js`
+* **Activation Events:** 
+* **Contribution Points:** authentication, configuration

--- a/docs/extension-architecture/notebook-renderers.md
+++ b/docs/extension-architecture/notebook-renderers.md
@@ -1,0 +1,9 @@
+# Builtin Notebook Output Renderers
+
+**Extension ID:** builtin-notebook-renderers
+
+Provides basic output renderers for notebooks
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** notebookRenderer

--- a/docs/extension-architecture/npm.md
+++ b/docs/extension-architecture/npm.md
@@ -1,0 +1,9 @@
+# NPM support for VS Code
+
+**Extension ID:** npm
+
+Extension to add task support for npm scripts.
+
+* **Entry Point:** `./out/npmMain`
+* **Activation Events:** onTaskType:npm, onLanguage:json, workspaceContains:package.json
+* **Contribution Points:** languages, views, commands, menus, configuration, jsonValidation, taskDefinitions, terminalQuickFixes

--- a/docs/extension-architecture/objective-c.md
+++ b/docs/extension-architecture/objective-c.md
@@ -1,0 +1,9 @@
+# Objective-C Language Basics
+
+**Extension ID:** objective-c
+
+Provides syntax highlighting and bracket matching in Objective-C files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/perl.md
+++ b/docs/extension-architecture/perl.md
@@ -1,0 +1,9 @@
+# Perl Language Basics
+
+**Extension ID:** perl
+
+Provides syntax highlighting and bracket matching in Perl files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/php-language-features.md
+++ b/docs/extension-architecture/php-language-features.md
@@ -1,0 +1,9 @@
+# PHP Language Features
+
+**Extension ID:** php-language-features
+
+Provides rich language support for PHP files.
+
+* **Entry Point:** `./out/phpMain`
+* **Activation Events:** onLanguage:php
+* **Contribution Points:** configuration, jsonValidation

--- a/docs/extension-architecture/php.md
+++ b/docs/extension-architecture/php.md
@@ -1,0 +1,9 @@
+# PHP Language Basics
+
+**Extension ID:** php
+
+Provides syntax highlighting and bracket matching for PHP files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/powershell.md
+++ b/docs/extension-architecture/powershell.md
@@ -1,0 +1,9 @@
+# Powershell Language Basics
+
+**Extension ID:** powershell
+
+Provides snippets, syntax highlighting, bracket matching and folding in Powershell files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/prompt-basics.md
+++ b/docs/extension-architecture/prompt-basics.md
@@ -1,0 +1,9 @@
+# Prompt Language Basics
+
+**Extension ID:** prompt
+
+Syntax highlighting for Prompt and Instructions documents.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/pug.md
+++ b/docs/extension-architecture/pug.md
@@ -1,0 +1,9 @@
+# Pug Language Basics
+
+**Extension ID:** pug
+
+Provides syntax highlighting and bracket matching in Pug files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/python.md
+++ b/docs/extension-architecture/python.md
@@ -1,0 +1,9 @@
+# Python Language Basics
+
+**Extension ID:** python
+
+Provides syntax highlighting, bracket matching and folding in Python files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/r.md
+++ b/docs/extension-architecture/r.md
@@ -1,0 +1,9 @@
+# R Language Basics
+
+**Extension ID:** r
+
+Provides syntax highlighting and bracket matching in R files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/razor.md
+++ b/docs/extension-architecture/razor.md
@@ -1,0 +1,9 @@
+# Razor Language Basics
+
+**Extension ID:** razor
+
+Provides syntax highlighting, bracket matching and folding in Razor files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/references-view.md
+++ b/docs/extension-architecture/references-view.md
@@ -1,0 +1,9 @@
+# Reference Search View
+
+**Extension ID:** references-view
+
+Reference Search results as separate, stable view in the sidebar
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onCommand:references-view.find, onCommand:editor.action.showReferences
+* **Contribution Points:** configuration, viewsContainers, views, commands, menus, keybindings

--- a/docs/extension-architecture/restructuredtext.md
+++ b/docs/extension-architecture/restructuredtext.md
@@ -1,0 +1,9 @@
+# reStructuredText Language Basics
+
+**Extension ID:** restructuredtext
+
+Provides syntax highlighting in reStructuredText files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/ruby.md
+++ b/docs/extension-architecture/ruby.md
@@ -1,0 +1,9 @@
+# Ruby Language Basics
+
+**Extension ID:** ruby
+
+Provides syntax highlighting and bracket matching in Ruby files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/rust.md
+++ b/docs/extension-architecture/rust.md
@@ -1,0 +1,9 @@
+# Rust Language Basics
+
+**Extension ID:** rust
+
+Provides syntax highlighting and bracket matching in Rust files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/scss.md
+++ b/docs/extension-architecture/scss.md
@@ -1,0 +1,9 @@
+# SCSS Language Basics
+
+**Extension ID:** scss
+
+Provides syntax highlighting, bracket matching and folding in SCSS files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, problemMatchers

--- a/docs/extension-architecture/search-result.md
+++ b/docs/extension-architecture/search-result.md
@@ -1,0 +1,9 @@
+# Search Result
+
+**Extension ID:** search-result
+
+Provides syntax highlighting and language features for tabbed search results.
+
+* **Entry Point:** `./out/extension.js`
+* **Activation Events:** onLanguage:search-result
+* **Contribution Points:** configurationDefaults, languages, grammars

--- a/docs/extension-architecture/shaderlab.md
+++ b/docs/extension-architecture/shaderlab.md
@@ -1,0 +1,9 @@
+# Shaderlab Language Basics
+
+**Extension ID:** shaderlab
+
+Provides syntax highlighting and bracket matching in Shaderlab files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/shellscript.md
+++ b/docs/extension-architecture/shellscript.md
@@ -1,0 +1,9 @@
+# Shell Script Language Basics
+
+**Extension ID:** shellscript
+
+Provides syntax highlighting and bracket matching in Shell Script files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/docs/extension-architecture/simple-browser.md
+++ b/docs/extension-architecture/simple-browser.md
@@ -1,0 +1,9 @@
+# Simple Browser
+
+**Extension ID:** simple-browser
+
+A very basic built-in webview for displaying web content.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onCommand:simpleBrowser.api.open, onOpenExternalUri:http, onOpenExternalUri:https, onWebviewPanel:simpleBrowser.view
+* **Contribution Points:** commands, configuration

--- a/docs/extension-architecture/sql.md
+++ b/docs/extension-architecture/sql.md
@@ -1,0 +1,9 @@
+# SQL Language Basics
+
+**Extension ID:** sql
+
+Provides syntax highlighting and bracket matching in SQL files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/swift.md
+++ b/docs/extension-architecture/swift.md
@@ -1,0 +1,9 @@
+# Swift Language Basics
+
+**Extension ID:** swift
+
+Provides snippets, syntax highlighting and bracket matching in Swift files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/terminal-suggest.md
+++ b/docs/extension-architecture/terminal-suggest.md
@@ -1,0 +1,9 @@
+# Terminal Suggest for VS Code
+
+**Extension ID:** terminal-suggest
+
+Extension to add terminal completions for zsh, bash, and fish terminals.
+
+* **Entry Point:** `./out/terminalSuggestMain`
+* **Activation Events:** onTerminalCompletionsRequested
+* **Contribution Points:** N/A

--- a/docs/extension-architecture/theme-abyss.md
+++ b/docs/extension-architecture/theme-abyss.md
@@ -1,0 +1,9 @@
+# Abyss Theme
+
+**Extension ID:** theme-abyss
+
+Abyss theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-defaults.md
+++ b/docs/extension-architecture/theme-defaults.md
@@ -1,0 +1,9 @@
+# Default Themes
+
+**Extension ID:** theme-defaults
+
+The default Visual Studio light and dark themes
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes, iconThemes

--- a/docs/extension-architecture/theme-kimbie-dark.md
+++ b/docs/extension-architecture/theme-kimbie-dark.md
@@ -1,0 +1,9 @@
+# Kimbie Dark Theme
+
+**Extension ID:** theme-kimbie-dark
+
+Kimbie dark theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-monokai-dimmed.md
+++ b/docs/extension-architecture/theme-monokai-dimmed.md
@@ -1,0 +1,9 @@
+# Monokai Dimmed Theme
+
+**Extension ID:** theme-monokai-dimmed
+
+Monokai dimmed theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-monokai.md
+++ b/docs/extension-architecture/theme-monokai.md
@@ -1,0 +1,9 @@
+# Monokai Theme
+
+**Extension ID:** theme-monokai
+
+Monokai theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-quietlight.md
+++ b/docs/extension-architecture/theme-quietlight.md
@@ -1,0 +1,9 @@
+# Quiet Light Theme
+
+**Extension ID:** theme-quietlight
+
+Quiet light theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-red.md
+++ b/docs/extension-architecture/theme-red.md
@@ -1,0 +1,9 @@
+# Red Theme
+
+**Extension ID:** theme-red
+
+Red theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-seti.md
+++ b/docs/extension-architecture/theme-seti.md
@@ -1,0 +1,9 @@
+# Seti File Icon Theme
+
+**Extension ID:** vscode-theme-seti
+
+A file icon theme made out of the Seti UI file icons
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** iconThemes

--- a/docs/extension-architecture/theme-solarized-dark.md
+++ b/docs/extension-architecture/theme-solarized-dark.md
@@ -1,0 +1,9 @@
+# Solarized Dark Theme
+
+**Extension ID:** theme-solarized-dark
+
+Solarized dark theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-solarized-light.md
+++ b/docs/extension-architecture/theme-solarized-light.md
@@ -1,0 +1,9 @@
+# Solarized Light Theme
+
+**Extension ID:** theme-solarized-light
+
+Solarized light theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/theme-tomorrow-night-blue.md
+++ b/docs/extension-architecture/theme-tomorrow-night-blue.md
@@ -1,0 +1,9 @@
+# Tomorrow Night Blue Theme
+
+**Extension ID:** theme-tomorrow-night-blue
+
+Tomorrow night blue theme for Visual Studio Code
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** themes

--- a/docs/extension-architecture/tunnel-forwarding.md
+++ b/docs/extension-architecture/tunnel-forwarding.md
@@ -1,0 +1,9 @@
+# Local Tunnel Port Forwarding
+
+**Extension ID:** tunnel-forwarding
+
+Allows forwarding local ports to be accessible over the internet.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onTunnel
+* **Contribution Points:** commands

--- a/docs/extension-architecture/typescript-basics.md
+++ b/docs/extension-architecture/typescript-basics.md
@@ -1,0 +1,9 @@
+# TypeScript Language Basics
+
+**Extension ID:** typescript
+
+Provides snippets, syntax highlighting, bracket matching and folding in TypeScript files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, semanticTokenScopes, snippets

--- a/docs/extension-architecture/typescript-language-features.md
+++ b/docs/extension-architecture/typescript-language-features.md
@@ -1,0 +1,9 @@
+# TypeScript and JavaScript Language Features
+
+**Extension ID:** typescript-language-features
+
+Provides rich language support for JavaScript and TypeScript.
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onLanguage:javascript, onLanguage:javascriptreact, onLanguage:typescript, onLanguage:typescriptreact, onLanguage:jsx-tags, onCommand:typescript.tsserverRequest, onCommand:_typescript.configurePlugin, onCommand:_typescript.learnMoreAboutRefactorings, onCommand:typescript.fileReferences, onTaskType:typescript, onLanguage:jsonc, onWalkthrough:nodejsWelcome
+* **Contribution Points:** jsonValidation, configuration, commands, menus, breakpoints, taskDefinitions, problemPatterns, problemMatchers

--- a/docs/extension-architecture/vb.md
+++ b/docs/extension-architecture/vb.md
@@ -1,0 +1,9 @@
+# Visual Basic Language Basics
+
+**Extension ID:** vb
+
+Provides snippets, syntax highlighting, bracket matching and folding in Visual Basic files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, snippets

--- a/docs/extension-architecture/vscode-api-tests.md
+++ b/docs/extension-architecture/vscode-api-tests.md
@@ -1,0 +1,9 @@
+# vscode-api-tests
+
+**Extension ID:** vscode-api-tests
+
+API tests for VS Code
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** 
+* **Contribution Points:** languageModels, chatParticipants, configuration, views, configurationDefaults, taskDefinitions, breakpoints, debuggers, interactiveSession, notebooks, statusBarItems

--- a/docs/extension-architecture/vscode-colorize-perf-tests.md
+++ b/docs/extension-architecture/vscode-colorize-perf-tests.md
@@ -1,0 +1,9 @@
+# vscode-colorize-perf-tests
+
+**Extension ID:** vscode-colorize-perf-tests
+
+Colorize performance tests for VS Code
+
+* **Entry Point:** `./out/colorizerTestMain`
+* **Activation Events:** onLanguage:json
+* **Contribution Points:** N/A

--- a/docs/extension-architecture/vscode-colorize-tests.md
+++ b/docs/extension-architecture/vscode-colorize-tests.md
@@ -1,0 +1,9 @@
+# vscode-colorize-tests
+
+**Extension ID:** vscode-colorize-tests
+
+Colorize tests for VS Code
+
+* **Entry Point:** `./out/colorizerTestMain`
+* **Activation Events:** onLanguage:json
+* **Contribution Points:** semanticTokenTypes, semanticTokenModifiers, semanticTokenScopes, productIconThemes

--- a/docs/extension-architecture/vscode-test-resolver.md
+++ b/docs/extension-architecture/vscode-test-resolver.md
@@ -1,0 +1,9 @@
+# vscode-test-resolver
+
+**Extension ID:** vscode-test-resolver
+
+Test resolver for VS Code
+
+* **Entry Point:** `./out/extension`
+* **Activation Events:** onResolveRemoteAuthority:test, onCommand:vscode-testresolver.newWindow, onCommand:vscode-testresolver.currentWindow, onCommand:vscode-testresolver.newWindowWithError, onCommand:vscode-testresolver.showLog, onCommand:vscode-testresolver.openTunnel, onCommand:vscode-testresolver.startRemoteServer, onCommand:vscode-testresolver.toggleConnectionPause
+* **Contribution Points:** resourceLabelFormatters, commands, menus, configuration

--- a/docs/extension-architecture/xml.md
+++ b/docs/extension-architecture/xml.md
@@ -1,0 +1,9 @@
+# XML Language Basics
+
+**Extension ID:** xml
+
+Provides syntax highlighting and bracket matching in XML files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars

--- a/docs/extension-architecture/yaml.md
+++ b/docs/extension-architecture/yaml.md
@@ -1,0 +1,9 @@
+# YAML Language Basics
+
+**Extension ID:** yaml
+
+Provides syntax highlighting and bracket matching in YAML files.
+
+* **Entry Point:** `N/A`
+* **Activation Events:** N/A
+* **Contribution Points:** languages, grammars, configurationDefaults

--- a/scripts/generateExtensionDocs.js
+++ b/scripts/generateExtensionDocs.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+
+const extensionsDir = path.join(__dirname, '..', 'extensions');
+const outputDir = path.join(__dirname, '..', 'docs', 'extension-architecture');
+
+if (!fs.existsSync(outputDir)) {
+  fs.mkdirSync(outputDir, { recursive: true });
+}
+
+function isExtensionDir(name) {
+  if (name.startsWith('.')) return false;
+  const fullPath = path.join(extensionsDir, name);
+  if (!fs.statSync(fullPath).isDirectory()) return false;
+  if (name.endsWith('.json') || name.endsWith('.js')) return false;
+  return true;
+}
+
+function resolveNlsValue(value, extDir) {
+  if (typeof value !== 'string') return value;
+  const match = /^%([^%]+)%$/.exec(value);
+  if (!match) return value;
+  const nlsPath = path.join(extDir, 'package.nls.json');
+  if (!fs.existsSync(nlsPath)) return value;
+  const nls = JSON.parse(fs.readFileSync(nlsPath, 'utf8'));
+  return nls[match[1]] || value;
+}
+
+for (const ext of fs.readdirSync(extensionsDir).filter(isExtensionDir)) {
+  const extDir = path.join(extensionsDir, ext);
+  const pkgPath = path.join(extDir, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const name = pkg.name || ext;
+  const displayName = resolveNlsValue(pkg.displayName || name, extDir);
+  const description = resolveNlsValue(pkg.description || '', extDir);
+  const main = pkg.main || 'N/A';
+  const activationEvents = Array.isArray(pkg.activationEvents) ? pkg.activationEvents.join(', ') : 'N/A';
+  const contributes = pkg.contributes ? Object.keys(pkg.contributes).join(', ') : 'N/A';
+
+  const doc = `# ${displayName}\n\n` +
+    `**Extension ID:** ${name}\n\n` +
+    (description ? `${description}\n\n` : '') +
+    `* **Entry Point:** \`${main}\`\n` +
+    `* **Activation Events:** ${activationEvents}\n` +
+    `* **Contribution Points:** ${contributes}\n`;
+
+  const outPath = path.join(outputDir, `${ext}.md`);
+  fs.writeFileSync(outPath, doc);
+  console.log(`Generated ${outPath}`);
+}


### PR DESCRIPTION
## Summary
- generate documentation for built-in extensions
- add helper script to regenerate docs

## Testing
- `npm test`
- `node scripts/generateExtensionDocs.js`

------
https://chatgpt.com/codex/tasks/task_e_686c9a5789f08331bdbac37d1b69df27